### PR TITLE
Fix a minor mistake in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ It should look like this after:
 
 <img width="859" height="182" alt="image" src="https://github.com/user-attachments/assets/7cd062fc-6768-44d1-a2f1-99b897e11869" />
 
-7. In your `admin_panel` folder, create a new folder named `achievement`
+7. In the first `admin_panel` (not the second), create a new folder named `achievement`
 
 8. Copy and paste the files from the "achievement" folder (including the migrations folder) into the achievement folder you made.
 


### PR DESCRIPTION
In step 7, I told people to go to the `admin_panel` to put the achievement folder inside it. I didn't notice that I didn't specify which folder to put it in since there are 2 of them and someone put the folder in the second admin_panel instead of the first. I have now made it more clear to put it in the first folder and not the second folder.